### PR TITLE
Add fallback local url to marketo

### DIFF
--- a/utils/marketo.ts
+++ b/utils/marketo.ts
@@ -1,22 +1,28 @@
 import { useState, useEffect } from "react";
 
+const { NEXT_PUBLIC_HOST } = process.env;
 const { NEXT_PUBLIC_MARKTO_MUNCHKIN_ID } = process.env;
 const { NEXT_PUBLIC_MARKTO_BASE_URL } = process.env;
 
-function loadScript(): Promise<boolean> {
-  return new Promise((resolve) => {
-    if (window.MktoForms2) {
-      return resolve(true);
+function loadScript(baseUrl: string): Promise<string> {
+  const url = `${baseUrl}/js/forms2/js/forms2.min.js`;
+
+  return new Promise((resolve, reject) => {
+    if (window.MktoForms2 && document.querySelector(`script[src=${url}]`)) {
+      return resolve(baseUrl);
     }
 
     const scriptElement = document.createElement("script");
 
-    scriptElement.src = `${NEXT_PUBLIC_MARKTO_BASE_URL}/js/forms2/js/forms2.min.js`;
     scriptElement.onload = () => {
       if (window.MktoForms2) {
-        return resolve(true);
+        return resolve(baseUrl);
       }
     };
+
+    scriptElement.onerror = () => reject(new Error("Can't load script"));
+
+    scriptElement.src = `${baseUrl}/js/forms2/js/forms2.min.js`;
 
     document.body.appendChild(scriptElement);
   });
@@ -28,21 +34,25 @@ interface UseMarketoProps {
 }
 
 export function useMarketo({ formId, callback }: UseMarketoProps): boolean {
-  const [loaded, setLoaded] = useState(false);
+  const [url, setUrl] = useState<string>(undefined);
 
   useEffect(() => {
-    if (!loaded) {
-      loadScript().then(setLoaded);
+    if (!url) {
+      loadScript(NEXT_PUBLIC_MARKTO_BASE_URL)
+        .catch(() => loadScript(NEXT_PUBLIC_HOST))
+        .then(setUrl)
+        .catch((e) => console.error(e));
+
       return;
     }
 
     window.MktoForms2.loadForm(
-      NEXT_PUBLIC_MARKTO_BASE_URL,
+      url,
       NEXT_PUBLIC_MARKTO_MUNCHKIN_ID,
       formId,
       callback
     );
-  }, [loaded, formId, callback]);
+  }, [url, formId, callback]);
 
-  return loaded;
+  return Boolean(url);
 }

--- a/utils/marketo.ts
+++ b/utils/marketo.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 const { NEXT_PUBLIC_HOST } = process.env;
 const { NEXT_PUBLIC_MARKTO_MUNCHKIN_ID } = process.env;
@@ -34,7 +34,9 @@ interface UseMarketoProps {
 }
 
 export function useMarketo({ formId, callback }: UseMarketoProps): boolean {
-  const [url, setUrl] = useState<string>(undefined);
+  const [url, setUrl] = useState<string>("");
+
+  const callbackRef = useRef(callback);
 
   useEffect(() => {
     if (!url) {
@@ -46,13 +48,10 @@ export function useMarketo({ formId, callback }: UseMarketoProps): boolean {
       return;
     }
 
-    window.MktoForms2.loadForm(
-      url,
-      NEXT_PUBLIC_MARKTO_MUNCHKIN_ID,
-      formId,
-      callback
-    );
-  }, [url, formId, callback]);
+    const cb = () => callbackRef.current();
+
+    window.MktoForms2.loadForm(url, NEXT_PUBLIC_MARKTO_MUNCHKIN_ID, formId, cb);
+  }, [url, formId, callbackRef]);
 
   return Boolean(url);
 }

--- a/utils/marketo.ts
+++ b/utils/marketo.ts
@@ -48,7 +48,11 @@ export function useMarketo({ formId, callback }: UseMarketoProps): boolean {
       return;
     }
 
-    const cb = () => callbackRef.current();
+    const cb = () => {
+      if (callbackRef.current) {
+        callbackRef.current();
+      }
+    };
 
     window.MktoForms2.loadForm(url, NEXT_PUBLIC_MARKTO_MUNCHKIN_ID, formId, cb);
   }, [url, formId, callbackRef]);


### PR DESCRIPTION
Fix #327

Marketo didn't work in Firefox and Safari because of tracking cookie protection. This PR adds optional proxying for the Marketo request view goteleport.com domain if the original script is blocked.

To make it work we need to add following rewrites to nginx:

- `^js/forms2/(.*)` -> `http://app-ab44.marketo.com/js/forms2/$1`
- `^form/getForm` -> `http://app-ab44.marketo.com/form/getForm`
- `^form/getKnownLead` -> `http://app-ab44.marketo.com/form/getKnownLead`
- `^index.php/leadCapture/save2` -> `http://app-ab44.marketo.com/index.php/leadCapture/save2`

CC @klizhentas ^
