### PR TITLE
Fix #324: Content and url update for `enterprise-trial`

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,5 +25,12 @@
       "name": "7.0",
       "branch": "master"
     }
+  ],
+  "redirects": [
+    {
+      "source": "/enterprise-trial/",
+      "destination": "/teleport-demo/",
+      "permanent": true
+    }
   ]
 }

--- a/pages/teleport-demo/index.mdx
+++ b/pages/teleport-demo/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: Get Started with Teleport
+title: Request a demo of Teleport
 h1: Teleport
-description: Teleport helps developers & security professionals quickly and securely access servers, applications, Kubernetes clusters, and databases from anywhere, across all environments.
+description: Teleport helps developers & security professionals quickly and securely access servers, applications, Kubernetes clusters, and databases from anywhere, across all environments. Chat with our team of solutions engineers to learn more about Teleport and how it could work for your particular use case.
 shortFooter: true
 layout: simple
 video: 0HlyGk8dihM


### PR DESCRIPTION
Fix #324

Will need to update redirects in nginx too.

CC @klizhentas : We need to add `/teleport-demo/` redirect.