### PR TITLE
Update edit button link

### DIFF
--- a/components/DocsPage/Header.tsx
+++ b/components/DocsPage/Header.tsx
@@ -85,7 +85,7 @@ const DocHeader = ({
             target="_blank"
             rel="noopener noreferrer"
           >
-            Suggest Improvement
+            Improve
           </Button>
         </Flex>
       )}

--- a/components/DocsPage/Header.tsx
+++ b/components/DocsPage/Header.tsx
@@ -85,7 +85,7 @@ const DocHeader = ({
             target="_blank"
             rel="noopener noreferrer"
           >
-            Edit
+            Suggest Improvement
           </Button>
         </Flex>
       )}

--- a/utils/docs-helpers.ts
+++ b/utils/docs-helpers.ts
@@ -35,7 +35,7 @@ export const getVersionConfigPath = (filepath: string) => {
 export const getGithubURL = (filepath: string) => {
   const current = getVersion(filepath);
   const root = getVersionRootPath(filepath);
-  const ghIssuePath = `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?assignees=&labels=documentation&template=documentation.md`;
+  const ghIssuePath = `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?labels=documentation&template=documentation.md`;
 
   return branches[current]
     ? `${ghIssuePath}&title=[v.${current}]%20${filepath.replace(root, "")}`

--- a/utils/docs-helpers.ts
+++ b/utils/docs-helpers.ts
@@ -33,7 +33,7 @@ export const getVersionConfigPath = (filepath: string) => {
 };
 
 export const getGithubURL = (filepath: string) => {
-  const current = getVersion(filepath); 
+  const current = getVersion(filepath);
   const root = getVersionRootPath(filepath);
   const ghIssuePath = `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?assignees=&labels=documentation&template=documentation.md`;
 

--- a/utils/docs-helpers.ts
+++ b/utils/docs-helpers.ts
@@ -33,13 +33,11 @@ export const getVersionConfigPath = (filepath: string) => {
 };
 
 export const getGithubURL = (filepath: string) => {
-  const current = getVersion(filepath);
+  const current = getVersion(filepath); 
   const root = getVersionRootPath(filepath);
+  const ghIssuePath = `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?assignees=&labels=documentation&template=documentation.md`;
 
   return branches[current]
-    ? filepath.replace(
-        root,
-        `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?assignees=&labels=documentation&template=documentation.md`
-      )
-    : "";
+    ? `${ghIssuePath}&title=[v.${current}]%20${filepath.replace(root, "")}`
+    : ghIssuePath;
 };

--- a/utils/docs-helpers.ts
+++ b/utils/docs-helpers.ts
@@ -39,7 +39,7 @@ export const getGithubURL = (filepath: string) => {
   return branches[current]
     ? filepath.replace(
         root,
-        `${NEXT_PUBLIC_GITHUB_DOCS}/edit/${branches[current]}`
+        `${NEXT_PUBLIC_GITHUB_DOCS}/issues/new?assignees=&labels=documentation&template=documentation.md`
       )
     : "";
 };


### PR DESCRIPTION
URL should create a documentation issue rather than a code edit/branch/PR.

- It will generate a URL like the following: https://github.com/gravitational/teleport/issues/new?assignees=&labels=documentation&template=documentation.md&title=[v.6.0]%20/docs/pages/cloud.mdx
- It will populate the Issue title field with the name of the file and version number.
- Addresses: https://github.com/gravitational/next/issues/251