### PR TITLE
filter '$' character from copied code text from docs pages

### DIFF
--- a/components/MDX/Pre.tsx
+++ b/components/MDX/Pre.tsx
@@ -7,6 +7,8 @@ import Code from "components/Code";
 import Icon from "components/Icon";
 import HeadlessButton from "components/HeadlessButton";
 
+import DeselectChar from "../../utils/deselect-character";
+
 interface CodeProps {
   children: ReactNode;
 }
@@ -22,7 +24,9 @@ const Pre = ({ children }: CodeProps) => {
     }
 
     if (codeRef.current) {
-      navigator.clipboard.writeText(codeRef.current.innerText);
+      navigator.clipboard.writeText(
+        DeselectChar("$", codeRef.current.innerText)
+      );
       setIsCopied(true);
 
       setTimeout(() => {

--- a/utils/deselect-character.test.ts
+++ b/utils/deselect-character.test.ts
@@ -1,0 +1,95 @@
+import deselectCharacter from "./deselect-character";
+
+describe("utils/deselectCharacter", () => {
+  it("case 1: single line code", () => {
+    const result = deselectCharacter(
+      "$",
+      "$ docker exec teleport tctl users add testuser --roles=editor,access --logins=root,ubuntu,ec2-user"
+    );
+
+    expect(result).toEqual(
+      "docker exec teleport tctl users add testuser --roles=editor,access --logins=root,ubuntu,ec2-user"
+    );
+  });
+
+  it("case 2: '#' commented text followed with single line code", () => {
+    const result = deselectCharacter(
+      "$",
+      `# Create local config and data directories for teleport, which will be mounted into the container
+       $ mkdir -p ~/teleport/config ~/teleport/data`
+    );
+
+    expect(result).toEqual(
+      `# Create local config and data directories for teleport, which will be mounted into the container
+       mkdir -p ~/teleport/config ~/teleport/data`
+    );
+  });
+
+  it("case 3: complex series of commented and command texts", () => {
+    const result = deselectCharacter(
+      "$",
+      `# Create local config and data directories for teleport, which will be mounted into the container
+       $ mkdir -p ~/teleport/config ~/teleport/data
+      
+      # Generate a sample teleport config and write it to the local config directory.
+      # This container will write the config and immediately exit - this is expected.
+      $ docker run --hostname localhost --rm \
+        --entrypoint=/bin/sh \
+        -v ~/teleport/config:/etc/teleport \
+        quay.io/gravitational/teleport:6 -c "teleport configure > /etc/teleport/teleport.yaml"
+      
+      # Start teleport with mounted config and data directories, plus all ports
+      $ docker run --hostname localhost --name teleport \
+        -v ~/teleport/config:/etc/teleport \
+        -v ~/teleport/data:/var/lib/teleport \
+        -p 3023:3023 -p 3025:3025 -p 3080:3080 \
+        quay.io/gravitational/teleport:6`
+    );
+
+    expect(result).toEqual(
+      `# Create local config and data directories for teleport, which will be mounted into the container
+       mkdir -p ~/teleport/config ~/teleport/data
+      
+      # Generate a sample teleport config and write it to the local config directory.
+      # This container will write the config and immediately exit - this is expected.
+      docker run --hostname localhost --rm \
+        --entrypoint=/bin/sh \
+        -v ~/teleport/config:/etc/teleport \
+        quay.io/gravitational/teleport:6 -c "teleport configure > /etc/teleport/teleport.yaml"
+      
+      # Start teleport with mounted config and data directories, plus all ports
+      docker run --hostname localhost --name teleport \
+        -v ~/teleport/config:/etc/teleport \
+        -v ~/teleport/data:/var/lib/teleport \
+        -p 3023:3023 -p 3025:3025 -p 3080:3080 \
+        quay.io/gravitational/teleport:6`
+    );
+  });
+
+  it("case 4: test if it does not break non-code texts", () => {
+    const result = deselectCharacter(
+      "$",
+      `WARNING: You are using insecure connection to SSH proxy https://localhost:3080
+      > Profile URL:        https://localhost:3080
+        Logged in as:       testuser
+        Cluster:            localhost
+        Roles:              admin
+        Logins:             root, ubuntu
+        Kubernetes:         disabled
+        Valid until:        2021-06-10 07:15:42 -0500 CDT [valid for 12h0m0s]
+        Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty`
+    );
+
+    expect(result).toEqual(
+      `WARNING: You are using insecure connection to SSH proxy https://localhost:3080
+      > Profile URL:        https://localhost:3080
+        Logged in as:       testuser
+        Cluster:            localhost
+        Roles:              admin
+        Logins:             root, ubuntu
+        Kubernetes:         disabled
+        Valid until:        2021-06-10 07:15:42 -0500 CDT [valid for 12h0m0s]
+        Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty`
+    );
+  });
+});

--- a/utils/deselect-character.ts
+++ b/utils/deselect-character.ts
@@ -1,0 +1,17 @@
+// deselectCharacter should remove given character from a sentence if it is the first character in that sentence
+const deselectCharacter = (char: string, text: string): string => {
+  const textArr = text.split("\n");
+  for (let i = 0; i < textArr.length; i++) {
+    // keep the whitespace count which we need to re-add while constructing sentence at last.
+    const wsCounter = textArr[i].length - textArr[i].trimLeft().length;
+    const txt = textArr[i].trimLeft();
+    if (txt.charAt(0) === char) {
+      const subs = txt.substring(2);
+      textArr[i] = " ".repeat(wsCounter) + subs;
+    }
+  }
+
+  return textArr.join("\n");
+};
+
+export default deselectCharacter;


### PR DESCRIPTION
A character filter function is implemented which removes a given character from a text line if it is the first character in that line. This should solve removing `$` character from code texts when copied from the copy button (2nd problem case as mentioned in https://github.com/gravitational/next/issues/166#issuecomment-886538864). 
