### PR TITLE
Delia/build badge component

### DIFF
--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -1,0 +1,26 @@
+import Flex from "components/Flex";
+import Icon from "components/Icon";
+
+export type Sizes = "xs" | "sm" | "md" | "lg" | "xl";
+
+export interface BadgeProps {
+  name: "code";
+  size: Sizes;
+}
+
+export const Badge = ({ name, size }: BadgeProps) => {
+  return (
+    <Flex
+      justifyContent="center"
+      alignItems="center"
+      bg="dark-purple"
+      border="1px solid white"
+      borderRadius="circle"
+      height={48}
+      width={48}
+      boxShadow="0px 8px 16px rgba(12, 12, 14, 0.24)"
+    >
+      <Icon name={name} size={size} />
+    </Flex>
+  );
+};

--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -1,11 +1,12 @@
 import Flex from "components/Flex";
 import Icon from "components/Icon";
+import type { IconName } from "../Icon/types";
 
-export type Sizes = "xs" | "sm" | "md" | "lg" | "xl";
+export type BadgeSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 export interface BadgeProps {
-  name: "code";
-  size: Sizes;
+  name: IconName;
+  size: BadgeSize;
 }
 
 export const Badge = ({ name, size }: BadgeProps) => {

--- a/components/Badge/index.ts
+++ b/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge as default } from "./Badge";

--- a/components/Company/clients.mdx
+++ b/components/Company/clients.mdx
@@ -68,7 +68,7 @@
 - id: blablacar
   title: BlaBlaCar
   industry:
-  - Technology
+    - Technology
 - id: carta
   title: Carta
 - id: carta1
@@ -465,7 +465,15 @@
   industry:
     - Technology
 - id: thredup
-  title: ThredUp
+  title: thredUP
+  industry:
+    - Retail
+- id: thredup1
+  title: thredUP
+  industry:
+    - Retail
+- id: thredup2
+  title: thredUP
   industry:
     - Retail
 - id: tokopedia

--- a/components/Company/logos.ts
+++ b/components/Company/logos.ts
@@ -116,6 +116,8 @@ export { default as swisscom } from "./logos/logo-swisscom.svg";
 export { default as telefonica } from "./logos/logo-telefonica.svg";
 export { default as threatstack } from "./logos/logo-threatstack.svg";
 export { default as thredup } from "./logos/logo-thredup.svg";
+export { default as thredup1 } from "./logos/logo-thredup.svg";
+export { default as thredup2 } from "./logos/logo-thredup.svg";
 export { default as tokopedia } from "./logos/logo-tokopedia.svg";
 export { default as touchsurgery } from "./logos/logo-touchsurgery.svg";
 export { default as transatel } from "./logos/logo-transatel.svg";

--- a/components/Feedback/data/reviews.mdx
+++ b/components/Feedback/data/reviews.mdx
@@ -157,7 +157,7 @@ linxo4:
   person:
     name: Pierre Klovsjö
     title: Engineer SysOps / DevOps
-    
+
 carta:
   text: Audit and recorded sessions in Teleport give us an understanding of exactly what was happening at any given moment. This is incredibly critical from a security and compliance perspective.
   person:
@@ -187,4 +187,16 @@ carta4:
   person:
     name: Mario Loria
     title: Senior Site Reliability Engineer II
+
+thredup1:
+  text: The biggest challenge was with newly onboarded developers, who had to go through a multi-step process to set up a custom solution.
+  person:
+    name: Roman Chepurnyi
+    title: Director of Infrastructure Engineering
+
+thredup2:
+  text: With our SOC2 audit, and likely future compliance requirements, using Teleport for high fidelity record-keeping bolstered our risk assessment and response competency.
+  person:
+    name: Roman Chepurnyi
+    title: Director of Infrastructure Engineering
 ---

--- a/components/index.ts
+++ b/components/index.ts
@@ -3,6 +3,7 @@ export { default as AnimationHeader } from "components/AnimationHeader";
 export { default as AnnouncementBar } from "components/AnnouncementBar";
 export { default as ApplicationAnimation } from "components/ApplicationAnimation";
 export { default as BackgroundViewer } from "components/BackgroundViewer";
+export { default as Badge } from "components/Badge";
 export { default as BaitCard } from "components/BaitCard";
 export { default as Banner } from "components/Banner";
 export { default as BookBlock } from "components/BookBlock";


### PR DESCRIPTION
# Problem
Create a new `Badge` component that renders existing `Icon` component

# Solution
- Create `Badge` component that takes 2 props:
1. `name` - the named export of an SVG Icon from `components/Icon/icons.ts`
2. `size` - one of 5 possible sizes (literal union type): `"xs" | "sm" | "md" | "lg" | "xl"`

- `Badge` renders the `Icon` component, passing both of it's props into `Icon` as props.

# Example Usage
- render `Badge` component in `pages/use-cases/saas/index.mdx`:
```
<Badge iconWrapper name="check" size="xs"/>
<Section>
 <Feedback reviews={meta.reviews} />
</Section>
<Badge iconWrapper name="circleCheck" size="lg"/>
```

Output on localhost:
- checkmarks on left hand side are `Badge`
<img width="1235" alt="Screen Shot 2021-11-11 at 1 31 20 PM" src="https://user-images.githubusercontent.com/70108137/141351445-55f45a29-baa6-438f-8c89-2da09c594e8a.png">

```
<Badge name="code" size="xl"/>
<Badge name="copy" size="lg"/>
<Section>
  <Feedback reviews={meta.reviews} />
</Section>

```

Output on localhost:
<img width="1088" alt="Screen Shot 2021-11-11 at 1 49 55 PM" src="https://user-images.githubusercontent.com/70108137/141352716-946dae7a-9747-4c49-8c10-9ec46d82b327.png">

# Questions 
- do we need a color prop to render the SVG in white?