### PR TITLE
Remove rewrites generator

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,6 @@ const mdxDocsOptions = require("./.build/server/mdx-config-docs");
 const { loadSiteConfig } = require("./.build/server/config");
 const {
   getRedirects,
-  getLatestVersionRewirites,
   generateSitemap,
   generateFullSitemap,
 } = require("./.build/server/paths");
@@ -19,7 +18,12 @@ const CONTENT_DIRECTORY = resolve(__dirname, "content");
 
 module.exports = withBundleAnalyzer({
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
-  rewrites: async () => getLatestVersionRewirites(),
+  rewrites: async () => [
+    {
+      source: "/docs/:path*",
+      destination: `/docs/ver/${latest}/:path*`,
+    },
+  ],
   redirects: async () => getRedirects(),
   images: {
     path: "/_next/image/",

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -64,18 +64,6 @@ const getSlugsForVersion = (version: string, filter: Identity = () => true) => {
     );
 };
 
-const getSlugDataListForVersion = (version: string) => {
-  const root = join("/ver", version);
-  const path = resolve("content", version, "docs/pages");
-
-  return getSlugsForVersion(version).map((filename) => {
-    return {
-      slug: filename.replace(/\/?(index)?.mdx?$/, "/").replace(path, root),
-      version,
-    };
-  });
-};
-
 const normalizeDocSlug = (slug: string, version: string) => {
   const isLatest = version === latest;
 
@@ -84,12 +72,6 @@ const normalizeDocSlug = (slug: string, version: string) => {
     (isLatest ? slug.replace(`/ver/${latest}`, "") : slug)
   );
 };
-
-export const getLatestVersionRewirites = () =>
-  getSlugDataListForVersion(latest).map(({ slug, version }) => ({
-    source: normalizeDocSlug(slug, version),
-    destination: NEXT_PUBLIC_DOCS_DIR + slug,
-  }));
 
 export const generateSitemap = () => {
   const sitePages = getNonDocsPaths().map((loc) => ({ loc }));


### PR DESCRIPTION
Older version of next.js had an error then using rewrite masks together with `trailingSlash: true`, so we had to generate rewrite rule for each docs page manually. But now this bug is fixed, so we can remove it. It will also save us ~20-30kb for the page bundle.