### PR TITLE
Remove duplicate section import bug

### DIFF
--- a/pages/kubernetes-access/index.mdx
+++ b/pages/kubernetes-access/index.mdx
@@ -11,7 +11,6 @@ import AnnouncementBar from "components/AnnouncementBar";
 import EasyStart from "components/EasyStart";
 import GridDisplay from "components/GridDisplay";
 import ProductBanner from "components/ProductBanner";
-import Section from "components/Section";
 import Terminal from "components/Terminal";
 import TerminalAnimation from "components/TerminalAnimation";
 import TryTeleport from "components/TryTeleport";


### PR DESCRIPTION
## Problem
Vercel build was failing bc `<Section />` was imported twice in `pages/kubernetes-access/index.mdx`:
<img width="1435" alt="Screen Shot 2022-01-18 at 1 39 24 PM" src="https://user-images.githubusercontent.com/70108137/149998615-ab153a01-8ef2-4fdc-96f2-0311af07ebc2.png">

## Solution
Remove duplicate import line
Preview `/kubernetes-access/` [here](https://teleport-docs-next-git-delia-fix-duplicate-2ea3ca-gravitational.vercel.app/kubernetes-access/)