### PR TITLE
`/blog` Semrush testing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,6 +25,10 @@ export default withBundleAnalyzer({
       source: "/docs/:path*",
       destination: `/docs/ver/${latest}/:path*`,
     },
+    {
+      source: '/blog/:path*',
+      destination: `https://teleport-blog-next.vercel.app/:path*`,
+    },
   ],
   redirects: async () => getRedirects(),
   outputFileTracing: false,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,7 @@ export default withBundleAnalyzer({
     },
     {
       source: '/blog/:path*',
-      destination: `https://teleport-blog-next.vercel.app/:path*`,
+      destination: `https://teleport-blog-next.vercel.app/blog/:path*`,
     },
   ],
   redirects: async () => getRedirects(),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,16 +20,16 @@ const CONTENT_DIRECTORY = resolve("content");
 
 export default withBundleAnalyzer({
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
-  rewrites: async () => [
-    {
-      source: "/docs/:path*",
-      destination: `/docs/ver/${latest}/:path*`,
-    },
-    {
-      source: '/blog/:path*',
-      destination: `https://teleport-blog-next.vercel.app/blog/:path*`,
-    },
-  ],
+  async rewrites() {
+    return {
+      fallback: [
+        {
+          source: "/docs/:path*",
+          destination: `/docs/ver/${latest}/:path*`,
+        },
+      ],
+    };
+  },
   redirects: async () => getRedirects(),
   outputFileTracing: false,
   images: {
@@ -50,7 +50,7 @@ export default withBundleAnalyzer({
     // silencing warnings until https://github.com/vercel/next.js/issues/33693 is resolved
     config.infrastructureLogging = {
       level: "error",
-    }
+    };
 
     config.output.assetModuleFilename = "static/media/[hash][ext]";
 

--- a/public/sitemapindex.xml
+++ b/public/sitemapindex.xml
@@ -10,7 +10,7 @@
 
    <sitemap>
 
-      <loc>https://goteleport.com/blog/sitemap.xml</loc>
+      <loc>https://teleport-blog-next.vercel.app/blog/sitemap.xml</loc>
 
    </sitemap>
 

--- a/public/sitemapindex.xml
+++ b/public/sitemapindex.xml
@@ -10,6 +10,12 @@
 
    <sitemap>
 
+      <loc>https://goteleport.com/blog/sitemap.xml</loc>
+
+   </sitemap>
+
+   <sitemap>
+
       <loc>https://goteleport.com/sitemap.xml</loc>
 
    </sitemap>


### PR DESCRIPTION
- updates sitemap index file with blog sitemap
- rewrites blog posts to `/blog` repo
- nginx redirects are handled in `/web` as: 
```
  location /blog/ {
            proxy_pass {{ next_url }};
        }
```

I _believe_ the redirect chain is as follows: 
request url: `https://gravitational.co/blog/aaa-security-protcols-for-network-access/`
1. nginx redirects all `/blog/` traffic to the next_url
2. next rewrites paths matching `/blog/:path*` to `https://teleport-blog-next.vercel.app/blog/:path*`

Sometimes, we're getting pageloads, but without images. Sometimes we're getting this: 
<img width="487" alt="Screen Shot 2022-02-28 at 4 13 52 PM" src="https://user-images.githubusercontent.com/73362670/156086012-1711a6e3-29cc-46a0-817b-acc2cb366c2f.png">

